### PR TITLE
Update conversion scripts

### DIFF
--- a/upload_to_hf.py
+++ b/upload_to_hf.py
@@ -1,4 +1,4 @@
-from transformers import AutoModel, AutoModelForSeq2SeqLM
+from transformers import AutoModel, AutoModelForSeq2SeqLM, AutoTokenizer
 import argparse
 
 parser = argparse.ArgumentParser()
@@ -8,11 +8,17 @@ parser.add_argument('--hub_model_name', type=str, default="",
                     help='Huggingface Organization name')
 parser.add_argument('--hf_org', type=str, default="",
                     help='Huggingface Organization name')
+parser.add_argument('--use_temp_dir', type=bool, default=False,
+                    help='Use this option if you see "you need to pass Repository a valid git clone" error')
 
 args = parser.parse_args()
 
 
 model = AutoModelForSeq2SeqLM.from_pretrained(args.model_path)
+tokenizer = AutoTokenizer.from_pretrained(args.model_path)
 print("✅ Loaded model")
-model.push_to_hub(args.hub_model_name, organization=args.hf_org)
+
+# For some reason, push_to_hub fails if use_temp_dir is False
+tokenizer.push_to_hub(args.hub_model_name, organization=args.hf_org, use_temp_dir=args.use_temp_dir)
+model.push_to_hub(args.hub_model_name, organization=args.hf_org, use_temp_dir=args.use_temp_dir)
 print("✅ Success")


### PR DESCRIPTION
add tokenizer to `upload_to_hf`
fix `upload_to_hf` error (you need to pass Repository a valid git clone) via adding `--use_temp_dir`
create repository in `convert.py` using `huggingface_hub.Repository` instead of `model.push_to_hub` (not tested)
